### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This repository is a [DDEV](https://ddev.readthedocs.io) add-on for providing [Hugo](https://gohugo.io) support.
 
-In DDEV addons can be installed from the command line using the `ddev add-on get` command, as in `ddev add-on get ddev/ddev-hugo`.
+In DDEV addons can be installed from the command line using the `ddev add-on get` command, as in `ddev add-on get penyaskito/ddev-hugo`.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 This repository is a [DDEV](https://ddev.readthedocs.io) add-on for providing [Hugo](https://gohugo.io) support.
 
-In DDEV addons can be installed from the command line using the `ddev get` command, as in `ddev get ddev/ddev-hugo`.
+In DDEV addons can be installed from the command line using the `ddev add-on get` command, as in `ddev add-on get ddev/ddev-hugo`.
 
 ## Getting started
 
 1. Create your ddev project with `ddev config --omit-containers=db --docroot public`
-2. Run `ddev get https://github.com/penyaskito/ddev-hugo`
+2. Run `ddev add-on get https://github.com/penyaskito/ddev-hugo` (or `ddev get https://github.com/penyaskito/ddev-hugo` if your version of DDEV is older than 1.23.5)
 3. Run `ddev exec hugo`
 4. Run `ddev launch`
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.